### PR TITLE
Update deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,5 +38,5 @@ jobs:
       run: |
         cf api https://api.london.cloud.service.gov.uk
         cf auth 
-        cf target -o cabinet-office-gsg -s  gsg-guidance
-        cf push -p build -b staticfile_buildpack gsg-technical-guidance
+        cf target -o cabinet-office-gsg -s gsg-guidance
+        cf push security-docs


### PR DESCRIPTION
This changes the 'Push to GOV.UK PaaS' action. Specifically, it removes the unnecessary extra commands in l. 42

I've also renamed it to security-docs, reflecting the name of the app in PaaS

I know I shouldn't say it, but it works on my machine - and I'm not yet sure how to test github actions locally