### PR TITLE
Correct embarrasssing typo

### DIFF
--- a/source/nginx.conf
+++ b/source/nginx.conf
@@ -60,7 +60,7 @@ http {
       <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_hsts")) %>
         add_header Strict-Transport-Security "max-age=31536000";
       <% end %>
-      if ($host != "wwww.security.gov.uk") {
+      if ($host != "www.security.gov.uk") {
         return 301 https://www.security.gov.uk$request_uri;
       }
     }


### PR DESCRIPTION
Yup, I even made a joke about it in the PR

I told the server to redirect to www.security.gov.uk if the host was not "wwww.security.gov.uk", which, why would it ever be? 

This is now fixed