### PR TITLE
Add main branch to correct "view source" links

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -34,3 +34,4 @@ prevent_indexing: false
 
 show_contribution_banner: true
 github_repo: cabinetoffice/gsg-guidance
+github_branch: main


### PR DESCRIPTION
Currently, URLs for the "View source" link at the bottom of pages are generated like:
`https://github.com/cabinetoffice/gsg-guidance/blob/master/source/...`
Where the `master` branch doesn't exist, the `github_branch` option sets the right branch for these links.