### PR TITLE
Only run the deploy workflow in source repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   build-and-push:
+    # only run on the source repo
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    
     environment: deploy
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This will stop the job automatically running on forks where it shouldn't (and doesn't) work because no access to the secrets to login to PaaS. 