### PR TITLE
Secure by design principles

### DIFF
--- a/source/guidance/index.html.md.erb
+++ b/source/guidance/index.html.md.erb
@@ -7,6 +7,9 @@ weight: 50
 
 This page contains various security-related guidance for use across government.
 
+## Secure by Design framework
+You can find the [Secure by Design framework here](/guidance/secure-by-design/).
+
 ## Social media guidance
 You can find the [social media guidance here](/guidance/social-media-guidance/).
 

--- a/source/guidance/secure-by-design/index.html.md.erb
+++ b/source/guidance/secure-by-design/index.html.md.erb
@@ -37,7 +37,7 @@ The Secure by Design framework aims to solve the following problems experienced 
 - re-position security assurance as a proportionate, streamlined and continuous process within digital service delivery so that delivery teams receive assurance requirements promptly, which are in line with [government’s cyber security assurance](https://www.gov.uk/government/publications/government-cyber-security-strategy-2022-to-2030/government-cyber-security-strategy-2022-to-2030-html#pillar-1-build-a-strong-foundation-of-organisational-cyber-security-resilience)
 - help architects design digital services using a consistent baseline for technical architectures commonly used across government
 
-#### Clear and easy-to-follow [principles](principles) will help organisations make sure that:
+#### A clear and easy-to-follow framework will help organisations make sure that:
 
 - cyber security is a core requirement for all government organisations
 - organisations have a reduced risk of reputational damage and other financial and operational impacts that can result from an attack

--- a/source/guidance/secure-by-design/index.html.md.erb
+++ b/source/guidance/secure-by-design/index.html.md.erb
@@ -14,9 +14,8 @@ The overarching aim of Secure by Design is to help organisations adopt a common 
 - security posture is continually assured throughout the digital [life cycle](https://csrc.nist.gov/glossary/term/life_cycle)
 
 
-We welcome feedback on the [10 Secure by Design Principles](principles), which are currently in **ALPHA** and open for consultation.
-
-You can email questions and comments to <secure-by-design@digital.cabinet-office.gov.uk>.
+> We welcome feedback on the [10 Secure by Design Principles](principles), which are currently in **ALPHA** and open for consultation.
+> You can email questions and comments to <secure-by-design@digital.cabinet-office.gov.uk>.
 
 ## User needs
 

--- a/source/guidance/secure-by-design/index.html.md.erb
+++ b/source/guidance/secure-by-design/index.html.md.erb
@@ -14,7 +14,7 @@ The overarching aim of Secure by Design is to help organisations adopt a common 
 - security posture is continually assured throughout the digital [life cycle](https://csrc.nist.gov/glossary/term/life_cycle)
 
 
-We welcome feedback on the [10 Secure by Design Principles](principles), which are currently in **ALPHA**.
+We welcome feedback on the [10 Secure by Design Principles](principles), which are currently in **ALPHA** and open for consultation.
 
 You can email questions and comments to <secure-by-design@digital.cabinet-office.gov.uk>.
 

--- a/source/guidance/secure-by-design/index.html.md.erb
+++ b/source/guidance/secure-by-design/index.html.md.erb
@@ -1,0 +1,49 @@
+---
+title: Government Secure by Design Framework
+weight: 60
+---
+
+# Government Secure by Design Framework
+
+The Central Digital and Data Office, in close collaboration with the cross-government Secure by Design working group, and expert advice from NCSC is developing a common Secure by Design framework and principles for government. This work is part of the [Government Cyber Security Strategy](https://www.gov.uk/government/publications/government-cyber-security-strategy-2022-to-2030) (outcome 9) and [Transforming for a digital future: 2022 to 2025 roadmap for digital and data](https://www.gov.uk/government/publications/roadmap-for-digital-and-data-2022-to-2025/transforming-for-a-digital-future-2022-to-2025-roadmap-for-digital-and-data#how-will-this-make-government-more-efficient) (commitment 11).
+
+The overarching aim of Secure by Design is to help organisations adopt a common approach for securing digital services that ensures:
+
+- appropriate and proportionate cyber security measures are embedded within the delivery of digital services from the start
+- risks are effectively managed at the right level and on an ongoing basis
+- security posture is continually assured throughout the digital [life cycle](https://csrc.nist.gov/glossary/term/life_cycle)
+
+
+We welcome feedback on the [10 Secure by Design Principles](principles), which are currently in **ALPHA**.
+
+You can email questions and comments to <secure-by-design@digital.cabinet-office.gov.uk>.
+
+## User needs
+
+The Secure by Design framework aims to solve the following problems experienced by the digital and security communities across government:
+
+1. Senior leadership often do not understand cyber security as a unified part of managing delivery risk (they think it’s a technical problem for later) and therefore do not sponsor cyber security risk management and assurance.
+1. The application of continuous cyber security risk management is currently not seamlessly integrated into project delivery methodologies.
+1. Security assurance is typically seen as a “necessary evil”, does not keep up with changing context, often is a tick box exercise and does not produce the right visibility of cyber issues to help leadership prioritise wider technology and security spend.
+1. Risk management and assurance documents are often cumbersome and do not demonstrate meaningful measures of effective security risk management.
+1. There is a lack of a consistent approach with regards to security design for technical architectures commonly used across government. This lack of consistency erodes the trust between public sector organisations, prevents easy data sharing and development of joint services and increases the time and cost of delivery.
+
+## Goals and outcomes of the framework
+
+#### The [principles](principles) are part of the Secure by Design framework which aims to provide practical guidance, tools and artefacts that:
+
+- help senior management to competently own their business cyber risk and provide a “code of conduct” for business risk owners
+- integrate security risk management activities as a dynamic and continuous process within digital service delivery
+- re-position security assurance as a proportionate, streamlined and continuous process within digital service delivery so that delivery teams receive assurance requirements promptly, which are in line with [government’s cyber security assurance](https://www.gov.uk/government/publications/government-cyber-security-strategy-2022-to-2030/government-cyber-security-strategy-2022-to-2030-html#pillar-1-build-a-strong-foundation-of-organisational-cyber-security-resilience)
+- help architects design digital services using a consistent baseline for technical architectures commonly used across government
+
+#### Clear and easy-to-follow [principles](principles) will help organisations make sure that:
+
+- cyber security is a core requirement for all government organisations
+- organisations have a reduced risk of reputational damage and other financial and operational impacts that can result from an attack
+- cyber security risks are treated as a business risk, even though attacks take place through digital channels
+- security controls are baked into the service right from the start and in line with the organisation's risk appetite
+- digital and security specialists work collaboratively using the same design books
+- digital services are built faster and on the same security specifications
+- non-security SMEs are upskilled by sharing comprehensive cyber security guidance based on their needs
+- cyber security risk management and assurance effectively contribute to improving the cyber resilience of government as a whole

--- a/source/guidance/secure-by-design/principles/index.html.md.erb
+++ b/source/guidance/secure-by-design/principles/index.html.md.erb
@@ -24,7 +24,7 @@ Performing security due diligence of technology products and open-source code al
 ----
 
 ## Principle 3 - Design risk-driven security
-Continuously optimise security controls taking into account the risk appetite, [situational awareness](https://csrc.nist.gov/glossary/term/situational_awareness) and supply chain shared responsibility model, not overlooking relevant [good practice](https://csrc.nist.gov/glossary/term/best_practice) protections.  
+Continuously optimise security controls taking into account the risk appetite, [situational awareness](https://csrc.nist.gov/glossary/term/situational_awareness) and supply chain shared responsibility model, not overlooking relevant [good practice](https://csrc.nist.gov/glossary/term/best_practice) protections.
 
 ### Intent of principle 3
 Dynamically managing risks and designing proportionate safeguards means that you can respond to changes in the risk profile appropriately to always have a current defensible position of your controls and mitigations.
@@ -32,7 +32,7 @@ Dynamically managing risks and designing proportionate safeguards means that you
 ----
 
 ## Principle 4 - Create usable security
-Carry out ongoing user research to make sure security controls are appropriate for the environment your users are working in and are easy to use.  
+Carry out ongoing user research to make sure security controls are appropriate for the environment your users are working in and are easy to use.
 
 ### Intent of principle 4
 Usable security allows users to effectively operate the security controls available to them. Unusable security forces users to work around it and adopt insecure practices to get things done.
@@ -48,7 +48,7 @@ By designing for security capabilities expanding across all functions of the cyb
 ----
 
 ## Principle 6 - Design flexible architectures
-Implement new services and update legacy systems with flexible architectures that allow scaling and easy integration of new security controls in response to business requirements, changing threats and vulnerabilities.  
+Implement new services and update legacy systems with flexible architectures that allow scaling and easy integration of new security controls in response to business requirements, changing threats and vulnerabilities.
 
 ### Intent of principle 6
 The use of flexible architectures allows services to readily adapt to meet new business requirements as well as respond quickly to changes in the security risk and threat landscape.
@@ -56,7 +56,7 @@ The use of flexible architectures allows services to readily adapt to meet new b
 ----
 
 ## Principle 7 - Minimise the attack surface
-Use only the required capabilities, software, data and hardware components necessary for the service to achieve its intended use.  
+Use only the required capabilities, software, data and hardware components necessary for the service to achieve its intended use.
 
 ### Intent of principle 7
 Minimising the [attack surface](https://csrc.nist.gov/glossary/term/attack_surface) reduces the opportunities for potential attackers to exploit vulnerabilities in the service without degrading the service.
@@ -82,5 +82,5 @@ Continually assuring the security posture of digital services provides the risk 
 ## Principle 10 - Secure changes
 Assess the security impact of proposed changes to digital services to ensure that their security and the way they work are not adversely affected.
 
-### Intent of  principle 10
+### Intent of principle 10
 To ensure that changes cannot be made to an operational service without proper consideration of how a change might affect its security, and management of that change through a secure design, development and deployment process.

--- a/source/guidance/secure-by-design/principles/index.html.md.erb
+++ b/source/guidance/secure-by-design/principles/index.html.md.erb
@@ -1,0 +1,83 @@
+# 10 Secure by Design Principles
+
+The following core principles are aimed at the digital and security communities delivering digital services. These cover the end-to-end digital service delivery life cycle addressing the challenges faced by government organisations. They are based on the [NCSC’s Secure Design Principles](https://www.ncsc.gov.uk/collection/cyber-security-design-principles), which focus on the design phase of cyber secure systems. The government principles take this basis and expand to cover the whole lifecycle, and are focussed on the needs of the public sector. Each principle is supplemented with an "intent" which illustrates the importance.
+
+----
+
+## Principle 1 – Appoint a business risk owner
+Appoint an appropriately senior risk owner, who has a clear reporting line to or is a member of the top management, to be accountable for owning the cyber security risks for the service throughout its life cycle and allocating security resources within the service delivery team.
+
+### Intent of principle 1
+By engaging an appropriately senior risk owner (project sponsor), you can make sure that cyber security risks are escalated to top management and managed by the most senior stakeholders in the business in accordance with the organisation’s risk appetite.
+
+----
+
+## Principle 2 - Perform security due diligence
+Continually assess the security of products or open-source code for security vulnerabilities, and mitigate the risks to your environment.
+
+### Intent of principle 2
+Performing security due diligence of technology products and open-source code allows you to make an informed business decision on the trade-offs between cyber security implications and efficiency. It enables sharing lessons-learnt with suppliers to help them improve the security of their products.
+
+----
+
+## Principle 3 - Design risk-driven security
+Continuously optimise security controls taking into account the risk appetite, [situational awareness](https://csrc.nist.gov/glossary/term/situational_awareness) and supply chain shared responsibility model, not overlooking relevant [good practice](https://csrc.nist.gov/glossary/term/best_practice) protections.  
+
+### Intent of principle 3
+Dynamically managing risks and designing proportionate safeguards means that you can respond to changes in the risk profile appropriately to always have a current defensible position of your controls and mitigations.
+
+----
+
+## Principle 4 - Create usable security
+Carry out ongoing user research to make sure security controls are appropriate for the environment your users are working in and are easy to use.  
+
+### Intent of principle 4
+Usable security allows users to effectively operate the security controls available to them. Unusable security forces users to work around it and adopt insecure practices to get things done.
+
+----
+
+## Principle 5 - Design security considering detective and responding measures
+Design and iterate security controls and processes to cover all stages of the services life cycle including capabilities to protect, detect, respond and recover from incidents.
+
+### Intent of principle 5
+By designing for security capabilities expanding across all functions of the cyber security framework, you reduce the likelihood of weak points where compromise could occur and go undetected.
+
+----
+
+## Principle 6 - Design flexible architectures
+Implement new services and update legacy systems with flexible architectures that allow scaling and easy integration of new security controls in response to business requirements, changing threats and vulnerabilities.  
+
+### Intent of principle 6
+The use of flexible architectures allows services to readily adapt to meet new business requirements as well as respond quickly to changes in the security risk and threat landscape.
+
+----
+
+## Principle 7 - Minimise the attack surface
+Use only the required capabilities, software, data and hardware components necessary for the service to achieve its intended use.  
+
+### Intent of principle 7
+Minimising the [attack surface](https://csrc.nist.gov/glossary/term/attack_surface) reduces the opportunities for potential attackers to exploit vulnerabilities in the service without degrading the service.
+
+----
+
+## Principle 8 - Defend in depth
+Assume any part of the service could be compromised at any point in its life cycle and design services so they cannot be wholly compromised if a single control has either failed or been overcome by an attacker.
+
+### Intent of principle 8
+By utilising layered controls effectively, it will increase the time and effort required by threat actors to fully compromise the service.
+
+----
+
+## Principle 9 - Build and embed continuous assurance
+Implement proportionate and evidence-based security assurance into the digital service life cycle to provide confidence in the effectiveness of the security controls.
+
+### Intent of principle 9
+Continually assuring the security posture of digital services provides the risk owners with the level of confidence that services operate securely and as intended.
+
+----
+
+## Principle 10 - Secure changes
+Assess the security impact of proposed changes to digital services to ensure that their security and the way they work are not adversely affected.
+
+### Intent of  principle 10
+To ensure that changes cannot be made to an operational service without proper consideration of how a change might affect its security, and management of that change through a secure design, development and deployment process.

--- a/source/guidance/secure-by-design/principles/index.html.md.erb
+++ b/source/guidance/secure-by-design/principles/index.html.md.erb
@@ -1,5 +1,9 @@
 # 10 Secure by Design Principles
 
+We welcome feedback on these principles, which are currently in **ALPHA** and open for consultation.
+
+You can email questions and comments to <secure-by-design@digital.cabinet-office.gov.uk>.
+
 The following core principles are aimed at the digital and security communities delivering digital services. These cover the end-to-end digital service delivery life cycle addressing the challenges faced by government organisations. They are based on the [NCSC’s Secure Design Principles](https://www.ncsc.gov.uk/collection/cyber-security-design-principles), which focus on the design phase of cyber secure systems. The government principles take this basis and expand to cover the whole lifecycle, and are focussed on the needs of the public sector. Each principle is supplemented with an "intent" which illustrates the importance.
 
 ----

--- a/source/guidance/secure-by-design/principles/index.html.md.erb
+++ b/source/guidance/secure-by-design/principles/index.html.md.erb
@@ -1,8 +1,7 @@
 # 10 Secure by Design Principles
 
-We welcome feedback on these principles, which are currently in **ALPHA** and open for consultation.
-
-You can email questions and comments to <secure-by-design@digital.cabinet-office.gov.uk>.
+> We welcome feedback on these principles, which are currently in **ALPHA** and open for consultation.
+> You can email questions and comments to <secure-by-design@digital.cabinet-office.gov.uk>.
 
 The following core principles are aimed at the digital and security communities delivering digital services. These cover the end-to-end digital service delivery life cycle addressing the challenges faced by government organisations. They are based on the [NCSC’s Secure Design Principles](https://www.ncsc.gov.uk/collection/cyber-security-design-principles), which focus on the design phase of cyber secure systems. The government principles take this basis and expand to cover the whole lifecycle, and are focussed on the needs of the public sector. Each principle is supplemented with an "intent" which illustrates the importance.
 


### PR DESCRIPTION
The addition is to include the secure by design principles under the guidance area of security.gov.uk

Change can be seen here:
[https://gsg-guidance.github.olliejc.uk/guidance/](https://gsg-guidance.github.olliejc.uk/guidance/)